### PR TITLE
default to release name if .Values.serviceAccount.name is omitted

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Create the name of the service account to use
 {{- if .Values.serviceAccount.create }}
 {{- default .Release.Name .Values.serviceAccount.name }}
 {{- else }}
-{{- "default" }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -55,9 +55,9 @@ Create the name of the service account to use
 */}}
 {{- define "wordpress-bedrock.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "wordpress-bedrock.fullname" .) .Values.serviceAccount.name }}
+{{- default .Release.Name .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- "default" }}
 {{- end }}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and create is true, a name is generated using the release name
   name:
   #iamRoleArn:
 
@@ -56,7 +56,7 @@ ingress:
 efs:
   enabled: false
   # fsid: fs-12345
-  # subPath: defaults to releasename
+  # subPath: defaults to release name
   awsRegion: eu-central-1
   extraDirs: []
 

--- a/values_test.yaml
+++ b/values_test.yaml
@@ -96,6 +96,6 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and create is true, a name is generated using the release name
   name: test-project
   iamRoleArn: arn:aws:iam::123456789012:role/test-project-role


### PR DESCRIPTION
- if `.Values.serviceAccount.create` is `true` and `.Values.serviceAccount.name` is set, use this name for the service account created.
- if `.Values.serviceAccount.create` is `true` and `.Values.serviceAccount.name` is **not** set, use the release name for the service account created (default setup for oidc).
- if `.Values.serviceAccount.create` is `false`, always stick to the `default` named existing service account