### PR TITLE
update external-secrets apiVersion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wordpress-bedrock
-version: 0.1.68
+version: 0.1.69

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -23,7 +23,7 @@ secretDescriptor:
 {{- end }}
 {{- if eq .Values.externalSecrets.engine "external-secrets" }}
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
   name: {{ include "wordpress-bedrock.fullname" . }}
@@ -41,7 +41,7 @@ spec:
       service: ParameterStore
       region: {{ .Values.externalSecrets.region }}
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ include "wordpress-bedrock.fullname" . }}


### PR DESCRIPTION
We get deprecation warnings on `helm upgrade`:

```
warnings.go:70] external-secrets.io/v1alpha1 ExternalSecret is deprecated; use external-secrets.io/v1beta1 ExternalSecret
warnings.go:70] external-secrets.io/v1alpha1 ExternalSecret is deprecated; use external-secrets.io/v1beta1 ExternalSecret
warnings.go:70] external-secrets.io/v1alpha1 SecretStore is deprecated; use external-secrets.io/v1beta1 SecretStore
warnings.go:70] external-secrets.io/v1alpha1 SecretStore is deprecated; use external-secrets.io/v1beta1 SecretStore
```

Upgrade-Guide: https://external-secrets.io/v0.5.7/guides-v1beta1/

We're currently running external-secrets 5.6.0 in our Clusters.