### PR TITLE
extend worker pods terminationGracePeriodSeconds to 60s

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wordpress-bedrock
-version: 0.1.99
+version: 0.1.100

--- a/templates/cron-job.yaml
+++ b/templates/cron-job.yaml
@@ -102,17 +102,6 @@ spec:
               {{- end }}
               {{- end }}
               {{- end }}
-          {{- range $key, $value := $.Values.externalSecrets.mapping }}
-              {{- if not (contains "wordpress-" $key) }}
-              {{- if not (contains "-root-" $key) }}
-              - name: {{ $key | upper | replace "-" "_" }}
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ template "wordpress-bedrock.fullname" $ }}
-                    key: {{ $key }}
-              {{- end }}
-              {{- end }}
-          {{- end }}
               {{- with $.Values.env }}
               {{- range $key, $value := . }}
               - name: {{ $key }}

--- a/templates/cron-job.yaml
+++ b/templates/cron-job.yaml
@@ -108,9 +108,6 @@ spec:
                 value: {{ $value | quote }}
               {{- end }}
               {{- end }}
-      {{- if $.Values.extraEnv }}
-{{ toYaml $.Values.extraEnv | indent 14 }}
-      {{- end }}
             volumeMounts:
             - mountPath: /usr/local/etc/php/conf.d/cron.ini
               name: config-volume

--- a/templates/cron-job.yaml
+++ b/templates/cron-job.yaml
@@ -1,11 +1,7 @@
 {{- if $.Values.cron.jobs }}
 {{- range $cronkey, $cronvalue := $.Values.cron.jobs }}
 {{- if $cronvalue.enabled }}
-{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
-{{- else -}}
-apiVersion: batch/v1beta1
-{{- end }}
 kind: CronJob
 metadata:
   {{- $nameMaxLength := len $cronkey | sub 51 | int }}

--- a/templates/deployment-exporter.yaml
+++ b/templates/deployment-exporter.yaml
@@ -56,17 +56,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-      {{- range $key, $value := .Values.externalSecrets.mapping }}
-          {{- if (contains "db-" $key) }}
-          {{- if not (contains "-root-" $key) }}
-          - name: WORDPRESS_{{ $key | upper | replace "-" "_" | replace "USERNAME" "USER" }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "wordpress-bedrock.fullname" $ }}
-                key: {{ $key }}
-          {{- end }}
-          {{- end }}
-      {{- end }}
           {{- with .Values.env }}
           {{- range $key, $value := . }}
           {{- if (contains "DB" $key) }}

--- a/templates/deployment-exporter.yaml
+++ b/templates/deployment-exporter.yaml
@@ -59,17 +59,11 @@ spec:
           {{- with .Values.env }}
           {{- range $key, $value := . }}
           {{- if (contains "DB" $key) }}
-          - name: {{ $key }}
+          - name: WORDPRESS_{{ $key }}
             value: {{ $value | quote }}
           {{- end }}
           {{- end }}
           {{- end }}
-      {{- range .Values.extraEnv }}
-          {{- if (contains "DB" .name) }}
-          - name: WORDPRESS_{{ .name }}
-            value: {{ .value }}
-          {{- end }}
-      {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.exporter.wordpress.port }}

--- a/templates/deployment-worker.yaml
+++ b/templates/deployment-worker.yaml
@@ -37,6 +37,8 @@ spec:
       serviceAccountName: {{ template "wordpress-bedrock.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      # extend the pods shutdown grace period from the default of 30s to 60s
+      terminationGracePeriodSeconds: 60
       initContainers:
         - name: copy-files
           securityContext:

--- a/templates/deployment-worker.yaml
+++ b/templates/deployment-worker.yaml
@@ -166,17 +166,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.externalSecrets.mapping }}
-            {{- if not (contains "wordpress-" $key) }}
-            {{- if not (contains "-root-" $key) }}
-          - name: {{ $key | upper | replace "-" "_" }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "wordpress-bedrock.fullname" $ }}
-                key: {{ $key }}
-            {{- end }}
-            {{- end }}
-          {{- end }}
           {{- with .Values.env }}
           {{- range $key, $value := . }}
           - name: {{ $key }}

--- a/templates/deployment-worker.yaml
+++ b/templates/deployment-worker.yaml
@@ -172,9 +172,6 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- end }}
-      {{- if .Values.extraEnv }}
-{{ toYaml .Values.extraEnv | indent 10 }}
-      {{- end }}
           resources:
             {{- toYaml .Values.php.resources | nindent 12 }}
 {{- if ( .Values.monitoring.enabled ) }}

--- a/templates/hook-jobs.yaml
+++ b/templates/hook-jobs.yaml
@@ -86,13 +86,6 @@ spec:
               name: {{ template "wordpress-bedrock.fullname" $ }}
               key: {{ $key | lower | replace "_" "-" }}
         {{- end }}
-    {{- range $key, $value := $.Values.externalSecrets.mapping }}
-        - name: {{ $key | upper | replace "-" "_" }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "wordpress-bedrock.fullname" $ }}
-              key: {{ $key }}
-    {{- end }}
         {{- with $.Values.env }}
         {{- range $key, $value := . }}
         - name: {{ $key }}

--- a/templates/hook-jobs.yaml
+++ b/templates/hook-jobs.yaml
@@ -92,9 +92,6 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-{{- if $.Values.extraEnv }}
-{{ toYaml $.Values.extraEnv | indent 8 }}
-{{- end }}
         volumeMounts:
           - mountPath: /etc/php/7.2/fpm/php-fpm.conf
             name: config-volume

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "wordpress-bedrock.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,32 +32,22 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if .pathType }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}-worker
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}-worker
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- else }}
           - path: "/*"
             pathType: "ImplementationSpecific"
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}-worker
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}-worker
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -20,10 +20,6 @@ secretDescriptor:
     - key: {{ $value }}
       name: {{ $key | lower | replace "_" "-" }}
   {{- end }}
-  {{- range $key, $value := .Values.externalSecrets.mapping }}
-    - key: {{ $value }}
-      name: {{ $key }}
-  {{- end }}
 {{- end }}
 {{- if eq .Values.externalSecrets.engine "external-secrets" }}
 ---
@@ -69,11 +65,6 @@ spec:
   data:
   {{- range $key, $value := .Values.externalSecrets.env }}
     - secretKey: {{ $key | lower | replace "_" "-" }}
-      remoteRef:
-        key: {{ $value }}
-  {{- end }}
-  {{- range $key, $value := .Values.externalSecrets.mapping }}
-    - secretKey: {{ $key }}
       remoteRef:
         key: {{ $value }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -128,16 +128,6 @@ php:
 env: {}
 #  FOO: bar
 
-# Additional environment variables to set.
-# extraEnv does not provide value merge accross multiple values files and thus is deprecated.
-extraEnv: []
-# extraEnv:
-#   - name: FOO
-#     valueFrom:
-#       secretKeyRef:
-#         key: FOO
-#         name: secret-resource
-
 # settings are used for WP Offload Media plugin
 offload:
   bucket: null

--- a/values.yaml
+++ b/values.yaml
@@ -194,14 +194,6 @@ externalSecrets:
 #    DB_PASSWORD: /dev/exampleblog/DB/password
 #    WORDPRESS_USERNAME: /dev/exampleblog/wordpress/username
 #    WORDPRESS_PASSWORD: /dev/exampleblog/wordpress/password
-  # 'mapping' is deprecated and will be removed in upcoming releases. Please use 'externalSecrets.env' instead.
-  mapping:
-#    db-root-username: /dev/wordpress-1/DB/username
-#    db-root-password: /dev/wordpress-1/DB/password
-#    db-username: /dev/exampleblog/DB/username
-#    db-password: /dev/exampleblog/DB/password
-#    wordpress-username: /dev/exampleblog/wordpress/username
-#    wordpress-password: /dev/exampleblog/wordpress/password
 
 monitoring:
   enabled: true


### PR DESCRIPTION
PreStop lifecycle hooks fail with following error. The containers get forcefully killed before these lifecycle hooks finish.

`Exec lifecycle hook ([/bin/bash -c sleep 30 && /usr/sbin/nginx -s quit]) for Container "wordpress-bedrock-nginx" in Pod "wp-xxx-wordpress-bedrock-worker" failed - error: command '/bin/bash -c sleep 30 && /usr/sbin/nginx -s quit' exited with 137: , message: ""`