### PR TITLE
use matchLabelKeys to select revision specific pods for spreading

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wordpress-bedrock
-version: 0.1.118
+version: 0.1.119

--- a/templates/deployment-worker.yaml
+++ b/templates/deployment-worker.yaml
@@ -316,6 +316,10 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: {{ .Release.Name }}
             app.kubernetes.io/component: "worker"
+        {{- if semverCompare ">=1.27-0" $.Capabilities.KubeVersion.GitVersion }}
+        matchLabelKeys:
+        - pod-template-hash
+        {{- end }}
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
@@ -323,6 +327,10 @@ spec:
           matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
               app.kubernetes.io/component: "worker"
+        {{- if semverCompare ">=1.27-0" $.Capabilities.KubeVersion.GitVersion }}
+        matchLabelKeys:
+        - pod-template-hash
+        {{- end }}
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition
